### PR TITLE
fix: use type from the reply nested content directly

### DIFF
--- a/.changeset/wise-coins-change.md
+++ b/.changeset/wise-coins-change.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-reply": patch
+---
+
+Gets the nested type of a reply from the deserialized EncodedContent instead of inspecting the parameter map

--- a/packages/content-type-reply/src/index.ts
+++ b/packages/content-type-reply/src/index.ts
@@ -1,2 +1,2 @@
 export { ReplyCodec, ContentTypeReply } from "./Reply";
-export type { Reply, ReplyParameters } from "./Reply";
+export type { Reply } from "./Reply";


### PR DESCRIPTION
This gets the nested type of a reply from the deserialized EncodedContent instead of inspecting the parameter map.

See also
https://github.com/xmtp/xmtp-ios/pull/143
https://github.com/xmtp/xmtp-android/pull/104

This is all part of 
https://github.com/xmtp/xmtp-react-native/pull/81