### PR TITLE
feat: add fallbacks to all the supported content types

### DIFF
--- a/.changeset/gorgeous-pugs-reply.md
+++ b/.changeset/gorgeous-pugs-reply.md
@@ -1,0 +1,8 @@
+---
+"@xmtp/content-type-remote-attachment": minor
+"@xmtp/content-type-read-receipt": minor
+"@xmtp/content-type-reaction": minor
+"@xmtp/content-type-reply": minor
+---
+
+Add dummy fallback field to all content types

--- a/packages/content-type-reaction/src/Reaction.ts
+++ b/packages/content-type-reaction/src/Reaction.ts
@@ -65,7 +65,7 @@ export class ReactionCodec implements ContentCodec<Reaction> {
     };
   }
 
-  fallback(content: Reaction): string | undefined {
+  fallback(): string | undefined {
     return "Error: Sorry, this app cannot display reactions";
   }
 }

--- a/packages/content-type-reaction/src/Reaction.ts
+++ b/packages/content-type-reaction/src/Reaction.ts
@@ -64,4 +64,8 @@ export class ReactionCodec implements ContentCodec<Reaction> {
       content: new TextDecoder().decode(content.content),
     };
   }
+
+  fallback(content: Reaction): string | undefined {
+    return "Error: Sorry, this app cannot display reactions";
+  }
 }

--- a/packages/content-type-read-receipt/src/ReadReceipt.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.ts
@@ -40,7 +40,7 @@ export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
     };
   }
 
-  fallback(content: ReadReceipt): string | undefined {
+  fallback(): string | undefined {
     return undefined;
   }
 }

--- a/packages/content-type-read-receipt/src/ReadReceipt.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.ts
@@ -39,4 +39,8 @@ export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
       timestamp,
     };
   }
+
+  fallback(content: ReadReceipt): string | undefined {
+    return undefined;
+  }
 }

--- a/packages/content-type-remote-attachment/src/Attachment.ts
+++ b/packages/content-type-remote-attachment/src/Attachment.ts
@@ -38,7 +38,7 @@ export class AttachmentCodec implements ContentCodec<Attachment> {
     };
   }
 
-  fallback(content: Attachment): string | undefined {
+  fallback(): string | undefined {
     return "Error: Sorry, this app cannot display attachments";
   }
 }

--- a/packages/content-type-remote-attachment/src/Attachment.ts
+++ b/packages/content-type-remote-attachment/src/Attachment.ts
@@ -37,4 +37,8 @@ export class AttachmentCodec implements ContentCodec<Attachment> {
       data: content.content,
     };
   }
+
+  fallback(content: Attachment): string | undefined {
+    return "Error: Sorry, this app cannot display attachments";
+  }
 }

--- a/packages/content-type-remote-attachment/src/RemoteAttachment.ts
+++ b/packages/content-type-remote-attachment/src/RemoteAttachment.ts
@@ -162,7 +162,7 @@ export class RemoteAttachmentCodec implements ContentCodec<RemoteAttachment> {
     };
   }
 
-  fallback(content: RemoteAttachment): string | undefined {
+  fallback(): string | undefined {
     return "Error: Sorry, this app cannot display attachments";
   }
 }

--- a/packages/content-type-remote-attachment/src/RemoteAttachment.ts
+++ b/packages/content-type-remote-attachment/src/RemoteAttachment.ts
@@ -161,4 +161,8 @@ export class RemoteAttachmentCodec implements ContentCodec<RemoteAttachment> {
       filename: content.parameters.filename,
     };
   }
+
+  fallback(content: RemoteAttachment): string | undefined {
+    return "Error: Sorry, this app cannot display attachments";
+  }
 }

--- a/packages/content-type-reply/src/Reply.ts
+++ b/packages/content-type-reply/src/Reply.ts
@@ -85,7 +85,7 @@ export class ReplyCodec implements ContentCodec<Reply> {
     };
   }
 
-  fallback(content: Reply): string | undefined {
+  fallback(): string | undefined {
     return "Error: Sorry, this app cannot display quote replies";
   }
 }

--- a/packages/content-type-reply/src/Reply.ts
+++ b/packages/content-type-reply/src/Reply.ts
@@ -84,4 +84,8 @@ export class ReplyCodec implements ContentCodec<Reply> {
       content: codec.decode(decodedContent as EncodedContent, codecs),
     };
   }
+
+  fallback(content: Reply): string | undefined {
+    return "Error: Sorry, this app cannot display quote replies";
+  }
 }


### PR DESCRIPTION
Dependent on: https://github.com/xmtp/xmtp-js/pull/426

This adds xmtp supported fallbacks to the content types.

Will need to bump the version to the latest JS SDK to get support for fallbacks.
