### PR TITLE
fix: normalize reaction encoding, support legacy form

### DIFF
--- a/.changeset/lazy-bananas-pretend.md
+++ b/.changeset/lazy-bananas-pretend.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-reaction": patch
+---
+
+- Normalize Reaction content type encoding, support legacy format

--- a/packages/content-type-reaction/src/Reaction.test.ts
+++ b/packages/content-type-reaction/src/Reaction.test.ts
@@ -11,11 +11,11 @@ describe("ReactionContentType", () => {
     expect(ContentTypeReaction.versionMinor).toBe(0);
   });
 
-  it("supports canonical and legacy form", async () => {
-    let codec = new ReactionCodec();
+  it("supports canonical and legacy form", () => {
+    const codec = new ReactionCodec();
 
     // This is how clients send reactions now.
-    let canonicalEncoded = {
+    const canonicalEncoded = {
       type: ContentTypeReaction,
       content: new TextEncoder().encode(
         JSON.stringify({
@@ -29,7 +29,7 @@ describe("ReactionContentType", () => {
 
     // Previously, some clients sent reactions like this.
     // So we test here to make sure we can still decode them.
-    let legacyEncoded = {
+    const legacyEncoded = {
       type: ContentTypeReaction,
       parameters: {
         action: "added",
@@ -39,8 +39,10 @@ describe("ReactionContentType", () => {
       content: new TextEncoder().encode("smile"),
     };
 
-    let canonical = codec.decode(canonicalEncoded as any);
-    let legacy = codec.decode(legacyEncoded as any);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const canonical = codec.decode(canonicalEncoded as any);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const legacy = codec.decode(legacyEncoded as any);
     expect(canonical.action).toBe("added");
     expect(legacy.action).toBe("added");
     expect(canonical.content).toBe("smile");

--- a/packages/content-type-reaction/src/Reaction.ts
+++ b/packages/content-type-reaction/src/Reaction.ts
@@ -27,7 +27,7 @@ export type Reaction = {
   schema: "unicode" | "shortcode" | "custom";
 };
 
-export type ReactionParameters = Pick<
+type LegacyReactionParameters = Pick<
   Reaction,
   "action" | "reference" | "schema"
 > & {
@@ -39,29 +39,40 @@ export class ReactionCodec implements ContentCodec<Reaction> {
     return ContentTypeReaction;
   }
 
-  encode(content: Reaction): EncodedContent<ReactionParameters> {
+  encode(reaction: Reaction): EncodedContent {
+    const { action, reference, schema, content } = reaction;
     return {
       type: ContentTypeReaction,
-      parameters: {
-        encoding: "UTF-8",
-        action: content.action,
-        reference: content.reference,
-        schema: content.schema,
-      },
-      content: new TextEncoder().encode(content.content),
+      parameters: {},
+      content: new TextEncoder().encode(
+        JSON.stringify({ action, reference, schema, content }),
+      ),
     };
   }
 
-  decode(content: EncodedContent<ReactionParameters>): Reaction {
-    const { encoding } = content.parameters;
+  decode(content: EncodedContent): Reaction {
+    let text = new TextDecoder().decode(content.content);
+
+    // First try to decode it in the canonical form.
+    try {
+      const reaction = JSON.parse(text);
+      const { action, reference, schema, content } = reaction;
+      return { action, reference, schema, content };
+    } catch (e) {
+      // ignore, fall through to legacy decoding
+    }
+
+    // If that fails, try to decode it in the legacy form.
+    let parameters = content.parameters as LegacyReactionParameters;
+    const { encoding } = parameters;
     if (encoding && encoding !== "UTF-8") {
       throw new Error(`unrecognized encoding ${encoding as string}`);
     }
     return {
-      action: content.parameters.action,
-      reference: content.parameters.reference,
-      schema: content.parameters.schema,
-      content: new TextDecoder().decode(content.content),
+      action: parameters.action,
+      reference: parameters.reference,
+      schema: parameters.schema,
+      content: text,
     };
   }
 }

--- a/packages/content-type-reaction/src/Reaction.ts
+++ b/packages/content-type-reaction/src/Reaction.ts
@@ -50,12 +50,12 @@ export class ReactionCodec implements ContentCodec<Reaction> {
     };
   }
 
-  decode(content: EncodedContent): Reaction {
-    let text = new TextDecoder().decode(content.content);
+  decode(encodedContent: EncodedContent): Reaction {
+    const decodedContent = new TextDecoder().decode(encodedContent.content);
 
     // First try to decode it in the canonical form.
     try {
-      const reaction = JSON.parse(text);
+      const reaction = JSON.parse(decodedContent) as Reaction;
       const { action, reference, schema, content } = reaction;
       return { action, reference, schema, content };
     } catch (e) {
@@ -63,16 +63,12 @@ export class ReactionCodec implements ContentCodec<Reaction> {
     }
 
     // If that fails, try to decode it in the legacy form.
-    let parameters = content.parameters as LegacyReactionParameters;
-    const { encoding } = parameters;
-    if (encoding && encoding !== "UTF-8") {
-      throw new Error(`unrecognized encoding ${encoding as string}`);
-    }
+    const parameters = encodedContent.parameters as LegacyReactionParameters;
     return {
       action: parameters.action,
       reference: parameters.reference,
       schema: parameters.schema,
-      content: text,
+      content: decodedContent,
     };
   }
 }

--- a/packages/content-type-reaction/src/index.ts
+++ b/packages/content-type-reaction/src/index.ts
@@ -1,2 +1,2 @@
 export { ReactionCodec, ContentTypeReaction } from "./Reaction";
-export type { Reaction, ReactionParameters } from "./Reaction";
+export type { Reaction } from "./Reaction";


### PR DESCRIPTION
This fixes the JS portion of how reactions are encoded across codec implementations.
See https://github.com/xmtp/xmtp-react-native/issues/93#issuecomment-1707220192