### PR TITLE
fix: remove timestamp from the read receipt content type

### DIFF
--- a/.changeset/fluffy-islands-retire.md
+++ b/.changeset/fluffy-islands-retire.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-read-receipt": patch
+---
+
+fix: remove timestamp from the read receipt content type

--- a/packages/content-type-read-receipt/src/ReadReceipt.test.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.test.ts
@@ -44,7 +44,7 @@ describe("ReadReceiptContentType", () => {
     expect(messages.length).toBe(1);
 
     const readReceiptMessage = messages[0];
-    const messageContent = readReceiptMessage.content as ReadReceipt;
-    expect(messageContent.timestamp).toBe(dateString);
+    const messageContent = readReceiptMessage.contentType;
+    expect(messageContent.typeId).toBe("readReceipt");
   });
 });

--- a/packages/content-type-read-receipt/src/ReadReceipt.test.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.test.ts
@@ -26,11 +26,7 @@ describe("ReadReceiptContentType", () => {
       bobWallet.address,
     );
 
-    const dateString = new Date().toISOString();
-
-    const readReceipt: ReadReceipt = {
-      timestamp: dateString,
-    };
+    const readReceipt: ReadReceipt = {};
 
     await conversation.send(readReceipt, {
       contentType: ContentTypeReadReceipt,

--- a/packages/content-type-read-receipt/src/ReadReceipt.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.ts
@@ -8,7 +8,7 @@ export const ContentTypeReadReceipt = new ContentTypeId({
   versionMinor: 0,
 });
 
-export type ReadReceipt = object;
+export type ReadReceipt = Record<string, never>;
 
 export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
   get contentType(): ContentTypeId {

--- a/packages/content-type-read-receipt/src/ReadReceipt.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.ts
@@ -8,36 +8,25 @@ export const ContentTypeReadReceipt = new ContentTypeId({
   versionMinor: 0,
 });
 
-export type ReadReceipt = {
-  /**
-   * The timestamp the read receipt was sent, in ISO 8601 format
-   */
-  timestamp: string;
-};
-
-export type ReadReceiptParameters = Pick<ReadReceipt, "timestamp">;
+export type ReadReceipt = object;
 
 export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
   get contentType(): ContentTypeId {
     return ContentTypeReadReceipt;
   }
 
-  encode(content: ReadReceipt): EncodedContent<ReadReceiptParameters> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  encode(content: ReadReceipt): EncodedContent {
     return {
       type: ContentTypeReadReceipt,
-      parameters: {
-        timestamp: content.timestamp,
-      },
+      parameters: {},
       content: new Uint8Array(),
     };
   }
 
-  decode(content: EncodedContent<ReadReceiptParameters>): ReadReceipt {
-    const { timestamp } = content.parameters;
-
-    return {
-      timestamp,
-    };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  decode(content: EncodedContent): ReadReceipt {
+    return {};
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/content-type-read-receipt/src/index.ts
+++ b/packages/content-type-read-receipt/src/index.ts
@@ -1,2 +1,2 @@
 export { ReadReceiptCodec, ContentTypeReadReceipt } from "./ReadReceipt";
-export type { ReadReceipt, ReadReceiptParameters } from "./ReadReceipt";
+export type { ReadReceipt } from "./ReadReceipt";


### PR DESCRIPTION
Addresses https://github.com/orgs/xmtp/discussions/43#discussioncomment-6972516

This removes the timestamp from the read receipt content type in favor of the timestamp already on the message.