### PR TITLE
Updated authority id

### DIFF
--- a/.changeset/wet-snakes-tap.md
+++ b/.changeset/wet-snakes-tap.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/experimental-content-type-screen-effect": patch
+---
+
+updated authority id

--- a/experimental/content-type-screen-effect/src/ScreenEffect.test.ts
+++ b/experimental/content-type-screen-effect/src/ScreenEffect.test.ts
@@ -5,7 +5,7 @@ import type { ScreenEffect } from "./ScreenEffect";
 
 describe("ScreenEffectContentType", () => {
   it("has the right content type", () => {
-    expect(ContentTypeScreenEffect.authorityId).toBe("xmtp.org");
+    expect(ContentTypeScreenEffect.authorityId).toBe("experimental.xmtp.org");
     expect(ContentTypeScreenEffect.typeId).toBe("screenEffect");
     expect(ContentTypeScreenEffect.versionMajor).toBe(1);
     expect(ContentTypeScreenEffect.versionMinor).toBe(0);

--- a/experimental/content-type-screen-effect/src/ScreenEffect.ts
+++ b/experimental/content-type-screen-effect/src/ScreenEffect.ts
@@ -4,7 +4,7 @@ import type { ContentCodec, EncodedContent } from "@xmtp/xmtp-js";
 export type EffectType = "SNOW" | "RAIN";
 
 export const ContentTypeScreenEffect = new ContentTypeId({
-  authorityId: "xmtp.org",
+  authorityId: "experimental.xmtp.org",
   typeId: "screenEffect",
   versionMajor: 1,
   versionMinor: 0,


### PR DESCRIPTION
Changed xmtp.org --> experimental.xmtp.org per discussion in this PR: https://github.com/xmtp/xmtp-dot-org/pull/626