### PR TITLE
Add `shouldPush` to all content codecs

### DIFF
--- a/.changeset/gorgeous-walls-mate.md
+++ b/.changeset/gorgeous-walls-mate.md
@@ -1,0 +1,10 @@
+---
+"@xmtp/experimental-content-type-screen-effect": patch
+"@xmtp/content-type-reaction": patch
+"@xmtp/content-type-read-receipt": patch
+"@xmtp/content-type-remote-attachment": patch
+"@xmtp/content-type-reply": patch
+"@xmtp/content-type-transaction-reference": patch
+---
+
+Add `shouldPush` to all content codecs

--- a/experimental/content-type-screen-effect/src/ScreenEffect.test.ts
+++ b/experimental/content-type-screen-effect/src/ScreenEffect.test.ts
@@ -54,4 +54,9 @@ describe("ScreenEffectContentType", () => {
     expect(messageContent.messageId).toBe(originalMessage.id);
     expect(messageContent.effectType).toBe("SNOW");
   });
+
+  it("has a proper shouldPush value", () => {
+    const codec = new ScreenEffectCodec();
+    expect(codec.shouldPush()).toBe(false);
+  });
 });

--- a/experimental/content-type-screen-effect/src/ScreenEffect.ts
+++ b/experimental/content-type-screen-effect/src/ScreenEffect.ts
@@ -52,4 +52,8 @@ export class ScreenEffectCodec
   fallback() {
     return undefined;
   }
+
+  shouldPush() {
+    return false;
+  }
 }

--- a/packages/content-type-reaction/src/Reaction.test.ts
+++ b/packages/content-type-reaction/src/Reaction.test.ts
@@ -97,4 +97,25 @@ describe("ReactionContentType", () => {
     expect(messageContent.reference).toBe(originalMessage.id);
     expect(messageContent.schema).toBe("shortcode");
   });
+
+  it("has a proper shouldPush value based on content", () => {
+    const codec = new ReactionCodec();
+
+    const addReaction: Reaction = {
+      action: "added",
+      content: "smile",
+      reference: "foo",
+      schema: "shortcode",
+    };
+
+    const removeReaction: Reaction = {
+      action: "removed",
+      content: "smile",
+      reference: "foo",
+      schema: "shortcode",
+    };
+
+    expect(codec.shouldPush(addReaction)).toBe(true);
+    expect(codec.shouldPush(removeReaction)).toBe(false);
+  });
 });

--- a/packages/content-type-reaction/src/Reaction.ts
+++ b/packages/content-type-reaction/src/Reaction.ts
@@ -82,4 +82,8 @@ export class ReactionCodec implements ContentCodec<Reaction> {
         return undefined;
     }
   }
+
+  shouldPush(content: Reaction): boolean {
+    return content.action === "added";
+  }
 }

--- a/packages/content-type-read-receipt/src/ReadReceipt.test.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.test.ts
@@ -47,4 +47,9 @@ describe("ReadReceiptContentType", () => {
     const messageContent = readReceiptMessage.contentType;
     expect(messageContent.typeId).toBe("readReceipt");
   });
+
+  it("has a proper shouldPush value", () => {
+    const codec = new ReadReceiptCodec();
+    expect(codec.shouldPush()).toBe(false);
+  });
 });

--- a/packages/content-type-read-receipt/src/ReadReceipt.ts
+++ b/packages/content-type-read-receipt/src/ReadReceipt.ts
@@ -33,4 +33,8 @@ export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
   fallback(content: ReadReceipt): string | undefined {
     return undefined;
   }
+
+  shouldPush() {
+    return false;
+  }
 }

--- a/packages/content-type-remote-attachment/src/Attachment.test.ts
+++ b/packages/content-type-remote-attachment/src/Attachment.test.ts
@@ -50,3 +50,8 @@ test("can send an attachment", async () => {
   expect(messageContent.mimeType).toBe("image/png");
   expect(messageContent.data).toStrictEqual(Uint8Array.from([5, 4, 3, 2, 1]));
 });
+
+test("has a proper shouldPush value", () => {
+  const codec = new AttachmentCodec();
+  expect(codec.shouldPush()).toBe(true);
+});

--- a/packages/content-type-remote-attachment/src/Attachment.ts
+++ b/packages/content-type-remote-attachment/src/Attachment.ts
@@ -41,4 +41,8 @@ export class AttachmentCodec implements ContentCodec<Attachment> {
   fallback(content: Attachment): string | undefined {
     return `Can’t display "${content.filename}". This app doesn’t support attachments.`;
   }
+
+  shouldPush() {
+    return true;
+  }
 }

--- a/packages/content-type-remote-attachment/src/RemoteAttachment.test.ts
+++ b/packages/content-type-remote-attachment/src/RemoteAttachment.test.ts
@@ -218,3 +218,8 @@ test("fails if content digest does not match", async () => {
     RemoteAttachmentCodec.load(message.content as RemoteAttachment, bobClient),
   ).rejects.toThrow("content digest does not match");
 });
+
+test("has a proper shouldPush value", () => {
+  const codec = new RemoteAttachmentCodec();
+  expect(codec.shouldPush()).toBe(true);
+});

--- a/packages/content-type-remote-attachment/src/RemoteAttachment.ts
+++ b/packages/content-type-remote-attachment/src/RemoteAttachment.ts
@@ -165,4 +165,8 @@ export class RemoteAttachmentCodec implements ContentCodec<RemoteAttachment> {
   fallback(content: RemoteAttachment): string | undefined {
     return `Can’t display "${content.filename}". This app doesn’t support attachments.`;
   }
+
+  shouldPush() {
+    return true;
+  }
 }

--- a/packages/content-type-reply/src/Reply.test.ts
+++ b/packages/content-type-reply/src/Reply.test.ts
@@ -110,4 +110,9 @@ describe("ReplyContentType", () => {
     });
     expect(messageContent.reference).toBe(originalMessage.id);
   });
+
+  it("has a proper shouldPush value", () => {
+    const codec = new ReplyCodec();
+    expect(codec.shouldPush()).toBe(true);
+  });
 });

--- a/packages/content-type-reply/src/Reply.ts
+++ b/packages/content-type-reply/src/Reply.ts
@@ -82,4 +82,8 @@ export class ReplyCodec implements ContentCodec<Reply> {
     }
     return "Replied to an earlier message";
   }
+
+  shouldPush() {
+    return true;
+  }
 }

--- a/packages/content-type-transaction-reference/src/TransactionReference.test.ts
+++ b/packages/content-type-transaction-reference/src/TransactionReference.test.ts
@@ -67,3 +67,8 @@ test("should successfully send and receive a TransactionReference message", asyn
   expect(messageContent.reference).toBe(transactionRefToSend.reference);
   expect(messageContent.metadata).toEqual(transactionRefToSend.metadata);
 });
+
+test("has a proper shouldPush value", () => {
+  const codec = new TransactionReferenceCodec();
+  expect(codec.shouldPush()).toBe(true);
+});

--- a/packages/content-type-transaction-reference/src/TransactionReference.ts
+++ b/packages/content-type-transaction-reference/src/TransactionReference.ts
@@ -64,4 +64,8 @@ export class TransactionReferenceCodec
     }
     return `Crypto transaction`;
   }
+
+  shouldPush() {
+    return true;
+  }
 }


### PR DESCRIPTION
# Summary

These changes are required when using a version of JS SDK that supports including the `shouldPush` and `senderHmac` attributes with messages.