### PR TITLE
Add content type primitives package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,5 +85,5 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: yarn
-      - name: Check types
-        run: yarn typecheck
+      - name: Build packages
+        run: yarn build

--- a/packages/content-type-primitives/.eslintrc.cjs
+++ b/packages/content-type-primitives/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ["custom"],
+  parserOptions: {
+    project: "./tsconfig.eslint.json",
+  },
+};

--- a/packages/content-type-primitives/LICENSE
+++ b/packages/content-type-primitives/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 XMTP (xmtp.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/content-type-primitives/README.md
+++ b/packages/content-type-primitives/README.md
@@ -1,0 +1,31 @@
+# Content type primitives
+
+This package provides primitives for building custom XMTP content types.
+
+## Install the package
+
+```bash
+# npm
+npm i @xmtp/content-type-primitives
+
+# yarn
+yarn add @xmtp/content-type-primitives
+
+# pnpm
+pnpm i @xmtp/content-type-primitives
+```
+
+## Developing
+
+Run `yarn dev` to build the content type primitives and watch for changes, which will trigger a rebuild.
+
+## Useful commands
+
+- `yarn build`: Builds the content type primitives
+- `yarn clean`: Removes `node_modules`, `dist`, and `.turbo` folders
+- `yarn dev`: Builds the content type and watches for changes, which will trigger a rebuild
+- `yarn format`: Runs Prettier format and write changes
+- `yarn format:check`: Runs Prettier format check
+- `yarn lint`: Runs ESLint
+- `yarn test`: Runs all unit tests
+- `yarn typecheck`: Runs `tsc`

--- a/packages/content-type-primitives/package.json
+++ b/packages/content-type-primitives/package.json
@@ -1,0 +1,94 @@
+{
+  "name": "@xmtp/content-type-primitives",
+  "version": "1.0.0",
+  "description": "Primitives for building custom XMTP content types",
+  "keywords": [
+    "xmtp",
+    "messaging",
+    "web3",
+    "js",
+    "ts",
+    "javascript",
+    "typescript",
+    "content-types"
+  ],
+  "homepage": "https://github.com/xmtp/xmtp-js-content-types",
+  "bugs": {
+    "url": "https://github.com/xmtp/xmtp-js-content-types/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:xmtp/xmtp-js-content-types.git",
+    "directory": "packages/content-type-primitives"
+  },
+  "license": "MIT",
+  "author": "XMTP Labs <eng@xmtp.com>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": "./dist/browser/index.js",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "browser": "dist/browser/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean:dist && yarn rollup -c",
+    "clean": "rimraf .turbo node_modules && yarn clean:dist",
+    "clean:dist": "rimraf dist",
+    "dev": "yarn clean:dist && yarn rollup -c --watch",
+    "format": "yarn format:base -w .",
+    "format:base": "prettier --ignore-path ../../.gitignore",
+    "format:check": "yarn format:base -c .",
+    "lint": "eslint . --ignore-path ../../.gitignore",
+    "test": "yarn test:node && yarn test:jsdom",
+    "test:jsdom": "NODE_TLS_REJECT_UNAUTHORIZED=0 vitest run --environment happy-dom",
+    "test:node": "NODE_TLS_REJECT_UNAUTHORIZED=0 vitest run --environment node",
+    "typecheck": "tsc --noEmit"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 3 chrome versions",
+      "last 3 firefox versions",
+      "last 3 safari versions"
+    ]
+  },
+  "dependencies": {
+    "@xmtp/proto": "^3.61.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@types/node": "^18.19.22",
+    "eslint": "^8.57.0",
+    "eslint-config-custom": "workspace:*",
+    "happy-dom": "^13.7.3",
+    "prettier": "^3.2.5",
+    "prettier-plugin-packagejson": "^2.4.12",
+    "rimraf": "^5.0.5",
+    "rollup": "^4.12.1",
+    "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-filesize": "^10.0.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.6",
+    "vitest": "^1.3.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/content-type-primitives/rollup.config.js
+++ b/packages/content-type-primitives/rollup.config.js
@@ -1,0 +1,58 @@
+import { defineConfig } from "rollup";
+import typescript from "@rollup/plugin-typescript";
+import { dts } from "rollup-plugin-dts";
+import terser from "@rollup/plugin-terser";
+import filesize from "rollup-plugin-filesize";
+
+const plugins = [
+  typescript({
+    declaration: false,
+    declarationMap: false,
+  }),
+  filesize({
+    showMinifiedSize: false,
+  }),
+];
+
+const external = ["@xmtp/proto"];
+
+export default defineConfig([
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.js",
+      format: "es",
+      sourcemap: true,
+    },
+    plugins,
+    external,
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/browser/index.js",
+      format: "es",
+      sourcemap: true,
+    },
+    plugins: [...plugins, terser()],
+    external,
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.cjs",
+      format: "cjs",
+      sourcemap: true,
+    },
+    plugins,
+    external,
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.d.ts",
+      format: "es",
+    },
+    plugins: [dts()],
+  },
+]);

--- a/packages/content-type-primitives/src/index.test.ts
+++ b/packages/content-type-primitives/src/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { ContentTypeId } from ".";
+
+describe("ContentTypeId", () => {
+  it("creates a new content type", () => {
+    const contentType = new ContentTypeId({
+      authorityId: "foo",
+      typeId: "bar",
+      versionMajor: 1,
+      versionMinor: 0,
+    });
+    expect(contentType.authorityId).toEqual("foo");
+    expect(contentType.typeId).toEqual("bar");
+    expect(contentType.versionMajor).toEqual(1);
+    expect(contentType.versionMinor).toEqual(0);
+  });
+
+  it("creates a string from a content type", () => {
+    const contentType = new ContentTypeId({
+      authorityId: "foo",
+      typeId: "bar",
+      versionMajor: 1,
+      versionMinor: 0,
+    });
+    expect(contentType.toString()).toEqual("foo/bar:1.0");
+  });
+
+  it("creates a content type from a string", () => {
+    const contentType = ContentTypeId.fromString("foo/bar:1.0");
+    expect(contentType.authorityId).toEqual("foo");
+    expect(contentType.typeId).toEqual("bar");
+    expect(contentType.versionMajor).toEqual(1);
+    expect(contentType.versionMinor).toEqual(0);
+  });
+
+  it("compares two content types", () => {
+    const contentType1 = new ContentTypeId({
+      authorityId: "foo",
+      typeId: "bar",
+      versionMajor: 1,
+      versionMinor: 0,
+    });
+    const contentType2 = new ContentTypeId({
+      authorityId: "baz",
+      typeId: "qux",
+      versionMajor: 1,
+      versionMinor: 0,
+    });
+    expect(contentType1.sameAs(contentType2)).toBe(false);
+    expect(contentType1.sameAs(contentType1)).toBe(true);
+  });
+});

--- a/packages/content-type-primitives/src/index.ts
+++ b/packages/content-type-primitives/src/index.ts
@@ -1,0 +1,54 @@
+import type { content } from "@xmtp/proto";
+
+export class ContentTypeId {
+  authorityId: string;
+
+  typeId: string;
+
+  versionMajor: number;
+
+  versionMinor: number;
+
+  constructor(obj: content.ContentTypeId) {
+    this.authorityId = obj.authorityId;
+    this.typeId = obj.typeId;
+    this.versionMajor = obj.versionMajor;
+    this.versionMinor = obj.versionMinor;
+  }
+
+  toString(): string {
+    return `${this.authorityId}/${this.typeId}:${this.versionMajor}.${this.versionMinor}`;
+  }
+
+  static fromString(contentTypeString: string): ContentTypeId {
+    const [idString, versionString] = contentTypeString.split(":");
+    const [authorityId, typeId] = idString.split("/");
+    const [major, minor] = versionString.split(".");
+    return new ContentTypeId({
+      authorityId,
+      typeId,
+      versionMajor: Number(major),
+      versionMinor: Number(minor),
+    });
+  }
+
+  sameAs(id: ContentTypeId): boolean {
+    return this.authorityId === id.authorityId && this.typeId === id.typeId;
+  }
+}
+
+export type EncodedContent<Parameters = Record<string, string>> = {
+  type: ContentTypeId;
+  parameters: Parameters;
+  fallback?: string;
+  compression?: number;
+  content: Uint8Array;
+};
+
+export type ContentCodec<T> = {
+  contentType: ContentTypeId;
+  encode(content: T): EncodedContent;
+  decode(content: EncodedContent): T;
+  fallback(content: T): string | undefined;
+  shouldPush: (content: T) => boolean;
+};

--- a/packages/content-type-primitives/tsconfig.eslint.json
+++ b/packages/content-type-primitives/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [".", ".eslintrc.cjs", "rollup.config.js"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/content-type-primitives/tsconfig.json
+++ b/packages/content-type-primitives/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/build.json",
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,6 +2003,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/content-type-primitives@workspace:packages/content-type-primitives":
+  version: 0.0.0-use.local
+  resolution: "@xmtp/content-type-primitives@workspace:packages/content-type-primitives"
+  dependencies:
+    "@rollup/plugin-terser": "npm:^0.4.4"
+    "@rollup/plugin-typescript": "npm:^11.1.6"
+    "@types/node": "npm:^18.19.22"
+    "@xmtp/proto": "npm:^3.61.1"
+    eslint: "npm:^8.57.0"
+    eslint-config-custom: "workspace:*"
+    happy-dom: "npm:^13.7.3"
+    prettier: "npm:^3.2.5"
+    prettier-plugin-packagejson: "npm:^2.4.12"
+    rimraf: "npm:^5.0.5"
+    rollup: "npm:^4.12.1"
+    rollup-plugin-dts: "npm:^6.1.0"
+    rollup-plugin-filesize: "npm:^10.0.0"
+    typescript: "npm:^5.4.2"
+    vite: "npm:^5.1.6"
+    vitest: "npm:^1.3.1"
+  languageName: unknown
+  linkType: soft
+
 "@xmtp/content-type-reaction@workspace:packages/content-type-reaction":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-reaction@workspace:packages/content-type-reaction"
@@ -2193,6 +2216,18 @@ __metadata:
     rxjs: "npm:^7.8.0"
     undici: "npm:^5.8.1"
   checksum: 10/b48b1d6628c923f4bd2c78916a9d79fcd5b5b8a2dbc89fcf20725b56ea84e332066ab0eb7148d806e79d0380a3d6f76787cf2fb5669b6fa31545dd045c8fd3a5
+  languageName: node
+  linkType: hard
+
+"@xmtp/proto@npm:^3.61.1":
+  version: 3.61.1
+  resolution: "@xmtp/proto@npm:3.61.1"
+  dependencies:
+    long: "npm:^5.2.0"
+    protobufjs: "npm:^7.0.0"
+    rxjs: "npm:^7.8.0"
+    undici: "npm:^5.8.1"
+  checksum: 10/c5acae46ad301a50652f30384be55a3389b4c11994652fa5386052c7ff4111fcb15c0e9d267898d6173cbcb6559b24bd7bef7470f020388f8610fecd3b8deea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This PR creates a new package that exports the building blocks for custom content types. This new package will remove the dependency on `@xmtp/xmtp-js` when creating new content types.

### First publish

The first version of this package will be published manually. Once published, a new granular NPM token will be created and added to this repo for future publishing.