### PR TITLE
Add more primitive types

### DIFF
--- a/.changeset/big-crabs-prove.md
+++ b/.changeset/big-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-primitives": patch
+---
+
+Add more primitive types

--- a/packages/content-type-primitives/package.json
+++ b/packages/content-type-primitives/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:xmtp/xmtp-js-content-types.git",
+    "url": "git+ssh://git@github.com/xmtp/xmtp-js-content-types.git",
     "directory": "packages/content-type-primitives"
   },
   "license": "MIT",

--- a/packages/content-type-primitives/src/index.ts
+++ b/packages/content-type-primitives/src/index.ts
@@ -52,3 +52,13 @@ export type ContentCodec<T> = {
   fallback(content: T): string | undefined;
   shouldPush: (content: T) => boolean;
 };
+
+/**
+ * An interface implemented for accessing codecs by content type.
+ * @deprecated
+ */
+export interface CodecRegistry<T = any> {
+  codecFor(contentType: ContentTypeId): ContentCodec<T> | undefined;
+}
+
+export type CodecMap<T = any> = Map<string, ContentCodec<T>>;


### PR DESCRIPTION
# Summary

* Added `CodecRegistry` type for compatibility with the JS SDK (deprecated)
* Added `CodecMap` type to be used in future implementations
* Fixed `package.json` repository URL