### PR TITLE
Fix rollup configs

### DIFF
--- a/experimental/content-type-screen-effect/rollup.config.js
+++ b/experimental/content-type-screen-effect/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/xmtp-js"];
+const external = ["@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {

--- a/packages/content-type-reaction/rollup.config.js
+++ b/packages/content-type-reaction/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/xmtp-js"];
+const external = ["@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {

--- a/packages/content-type-read-receipt/rollup.config.js
+++ b/packages/content-type-read-receipt/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/xmtp-js"];
+const external = ["@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {

--- a/packages/content-type-remote-attachment/rollup.config.js
+++ b/packages/content-type-remote-attachment/rollup.config.js
@@ -18,6 +18,7 @@ const plugins = [
 const external = [
   "@noble/secp256k1",
   "@xmtp/proto",
+  "@xmtp/content-type-primitives",
   "@xmtp/xmtp-js",
   "node:crypto",
 ];

--- a/packages/content-type-reply/rollup.config.js
+++ b/packages/content-type-reply/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/proto", "@xmtp/xmtp-js"];
+const external = ["@xmtp/proto", "@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {

--- a/packages/content-type-text/rollup.config.js
+++ b/packages/content-type-text/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/xmtp-js"];
+const external = ["@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {

--- a/packages/content-type-transaction-reference/rollup.config.js
+++ b/packages/content-type-transaction-reference/rollup.config.js
@@ -14,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/xmtp-js"];
+const external = ["@xmtp/content-type-primitives"];
 
 export default defineConfig([
   {


### PR DESCRIPTION
# Summary

* Updated `externals` for all rollup configs

No release required.